### PR TITLE
clean up mobile styles

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -299,17 +299,23 @@
         margin-right: 30px;
     }
 
-    .cofounders {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-        margin-top: 80px;
+    .codirectors {
+        /* margin-left: 10px;
+        margin-right: 10px; */
+
+        padding: 0 10px;
+    }
+
+    .codirector_row {
         padding: 0 20px;
     }
 
-    .cofounders h2 {
-        font-size: 1em;
+    .codirector_image h2 {
+        font-size: 1.3em;
+    }
+
+    .codirector_image img {
+        width: 80%;
     }
 
     .our_work {

--- a/css/team.css
+++ b/css/team.css
@@ -26,7 +26,6 @@
 .bio-box h1 {
     font-family: 'Mate SC', serif;
     font-size: 2.6em;
-
     position: relative;
     display: inline-block;
     padding: 0 10px;
@@ -92,13 +91,14 @@
         align-self: center;
     }
 
-
     .bio-box h1 {
-        font-family: 'Mate SC', serif;
-        font-size: 1.8em;
-        position: relative;
-        display: inline-block;
+        font-size: 1.6em;
         padding: 0 10px;
+    }
+
+    .bio-box h1::before {
+        height: 0.2m;
+        transform: translateY(-50%);
     }
 
     .bio-row {


### PR DESCRIPTION
hopefully this fixes 2 issues I saw on mobile version: 

1) codirectors row on home page looking wonky and uneven
2) educational content lead title having extra long yellow underline, though I might have to go back and fix this